### PR TITLE
Add simplified initializer for better readability

### DIFF
--- a/tests/transformer_test.py
+++ b/tests/transformer_test.py
@@ -1,0 +1,54 @@
+import pytest
+import numpy as np
+
+from tensorflow.keras.initializers import Constant as ConstantInit, GlorotUniform, Zeros
+from transunet.transformer import MultiHeadAttention
+
+
+def perform_attention_weights_test(expected_inits, hidden_size, w=None):
+    assert len(expected_inits) == 2, 'Number of expected inits must be 2. One for kernel, the others for bias'
+
+    attention = MultiHeadAttention(num_heads=6, w=w, name='attention')
+    attention.build(input_shape=(None, hidden_size))
+
+    keys = ['query', 'key', 'value', 'out']
+    for key, layer in zip(keys, [attention.query_dense, attention.key_dense, attention.values_dense, attention.dense]):
+        layer.build(input_shape=(None, hidden_size))
+
+        kernel_initializer = layer.kernel_initializer
+        bias_initializer = layer.bias_initializer
+
+        kernel_weights_key = 'attention/{}/kernel'.format(key)
+        bias_weights_key = 'attention/{}/bias'.format(key)
+
+        assert isinstance(kernel_initializer, expected_inits[0]), \
+            'Expected weights key: {}; attention name: {}'.format(kernel_weights_key, attention.name)
+        assert isinstance(bias_initializer, expected_inits[1]), \
+            'Expected weights key: {}, attention name: {}'.format(bias_weights_key, attention.name)
+
+        if w is not None:
+            layer_weights = layer.get_weights()
+            assert np.array_equal(layer_weights[0], w[kernel_weights_key])
+            assert np.array_equal(layer_weights[1], w[bias_weights_key])
+
+    return True
+
+
+def test_attention_initializers():
+    hidden_size = 1024 * 3
+    weights = {
+        'attention/query/kernel': np.ones((hidden_size, hidden_size)),
+        'attention/query/bias': np.zeros((hidden_size,)),
+        'attention/key/kernel': np.ones((hidden_size, hidden_size)),
+        'attention/key/bias': np.zeros((hidden_size,)),
+        'attention/value/kernel': np.ones((hidden_size, hidden_size)),
+        'attention/value/bias': np.zeros((hidden_size,)),
+        'attention/out/kernel': np.ones((hidden_size, hidden_size)),
+        'attention/out/bias': np.zeros((hidden_size,))
+    }
+    assert perform_attention_weights_test([ConstantInit, ConstantInit], hidden_size, w=weights)
+    assert perform_attention_weights_test([GlorotUniform, Zeros], hidden_size)
+
+
+if __name__ == '__main__':
+    pytest.main([__file__])

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -1,0 +1,47 @@
+import pytest
+import numpy as np
+
+from tensorflow.keras.initializers import Constant as ConstantInit
+from transunet.utils import default_initializers, default_initializer
+
+
+def test_default_initializer_usages():
+    weights = {
+        'block1_conv1': np.identity(5)
+    }
+    assert default_initializer('block1_conv1') is None
+    assert default_initializer('block1_conv1', default='glorot_uniform') == 'glorot_uniform'
+    assert default_initializer('block1_conv1') or 'glorot_uniform' == 'glorot_uniform'
+
+    assert isinstance(default_initializer('block1_conv1', w=weights), ConstantInit)
+    assert np.array_equal(default_initializer('block1_conv1', w=weights).value,
+                          ConstantInit(weights['block1_conv1']).value)
+
+    assert isinstance(default_initializer('block1_conv1', default='glorot_uniform', w=weights), ConstantInit)
+    assert default_initializer('block1_conv2',
+                               default='glorot_uniform',
+                               w=weights) == 'glorot_uniform'
+
+
+def test_default_initializers_usages():
+    scope_name = 'block1_conv1'
+    weights = {
+        f'{scope_name}/kernel': np.identity(5),
+        f'{scope_name}/bias': np.identity(5)
+    }
+    assert default_initializers(scope_name, ['kernel', 'bias']) == [None, None]
+    assert default_initializers(scope_name, ['kernel', 'bias'], defaults=['ones', 'zeros']) == ['ones', 'zeros']
+
+    inits = default_initializers(scope_name, ['kernel', 'bias'])
+    assert len(inits) == 2
+    assert inits[0] is None and inits[1] is None
+    assert inits[1] or 'zeros' == 'zeros'
+
+    inits = default_initializers(scope_name, ['kernel', 'bias'], w=weights)
+    assert len(inits) == 2
+    assert inits[0] is not None and inits[1] is not None
+    assert inits[1] or 'zeros' == weights['{}/bias'.format(scope_name)]
+
+
+if __name__ == '__main__':
+    pytest.main([__file__])

--- a/transunet/embedding.py
+++ b/transunet/embedding.py
@@ -22,10 +22,11 @@ class PositionEmbedding(Layer):
         assert len(input_shape) == 3, 'Expected ndim = 3, but ndim = {}'.format(len(input_shape))
 
         shape = (1, input_shape[1], input_shape[2])
-        if self.w is None:
+
+        key_name = '{}/pos_embedding'.format(self.name)
+        if self.w is None or key_name not in self.w:
             initializer = tf.random_normal_initializer(stddev=0.06)
         else:
-            key_name = '{}/pos_embedding'.format(self.name)
             weights = self.w[key_name]
             if shape == weights.shape:
                 initializer = ConstantInit(weights)

--- a/transunet/utils.py
+++ b/transunet/utils.py
@@ -1,0 +1,29 @@
+from typing import Union, Callable, Sequence, Optional
+from tensorflow.keras.initializers import Constant as ConstantInit
+
+
+def default_initializer(key: str, default: Optional[Union[str, Callable]] = None, w=None):
+    if w is not None and key in w:
+        return ConstantInit(w[key])
+    else:
+        return default
+
+
+def default_initializers(scope_name: str,
+                         keys: Sequence[str],
+                         defaults: Sequence[Optional[Union[str, Callable]]] = None,
+                         delimiter='/',
+                         w=None):
+
+    if defaults is not None:
+        assert len(keys) == len(defaults), 'Number of keys and default values must be equivalent'
+
+    initializers = []
+    for index, key in enumerate(keys):
+        key = '{}{}{}'.format(scope_name, delimiter, key)
+        if defaults is not None:
+            default = defaults[index]
+        else:
+            default = None
+        initializers.append(default_initializer(key, w=w, default=default))
+    return initializers


### PR DESCRIPTION
## Add simplified initializer for better readability

Returns constant initializer when `np.ndarray` or `tf.Tensor` weights are available.
Otherwise, returns default values or `None`.

#### default_initializer:
```python
initializer = default_initializer('dense0')
assert initializer is None
assert initializer or 'ones' == 'ones'
```
```python
initializer = default_initializer('dense0', w=weights)
assert initializer is not None
assert isinstance(initializer or 'ones', tf.keras.initializers.Constant)
assert np.array_equal(initializer.value, weights['dense0'])
```

#### default_initializers:
```python
inits = default_initializers('attention/keys', ['kernel', 'bias'])
assert len(inits) == 2
assert inits == [None, None]
assert inits[0] or 'ones' == 'ones'
```
```python
inits = default_initializers('attention/keys', ['kernel', 'bias'], w=weights)
assert len(inits) == 2
assert inits[0] is not None and inits[1] is not None
assert isinstance(inits[0], tf.keras.initializers.Constant)
```